### PR TITLE
Fix an issue that could not discharge when `discharge` method is called.

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -32,7 +32,7 @@ int rkmtlab::MultiEMS::Channel::drive()
 
 void rkmtlab::MultiEMS::Channel::discharge()
 {
-	digitalWrite(this->channelIdentifier() + 2, HIGH);
+	digitalWrite(this->channelIdentifier() + 2 + 4, HIGH);
 	delayMicroseconds(100);
-	digitalWrite(this->channelIdentifier() + 2, LOW);
+	digitalWrite(this->channelIdentifier() + 2 + 4, LOW);
 }


### PR DESCRIPTION
ArduinoのPIO6~9を使って放電する処理ができていなかったバグの修正です。

↓を参考に取り急ぎ修正しました(チャネル数4をハードコーディングした)。
https://github.com/rkmtlab/multi-ems/blob/d54c5d5db7e46c9572c0689a2bf4ad79d22269a8/ems_analog/emsFaceArd_v3/emsFaceArd_v3.ino#L45
